### PR TITLE
feat: Add integration tests for admin login and worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+## Working with the `django-cf` Repository
+
+This document provides guidance for AI agents working on the `django-cf` repository.
+
+### Project Overview
+
+`django-cf` is a Django application designed to run on Cloudflare Workers. It utilizes Cloudflare D1 for its database and Durable Objects for stateful operations. The core of this example project is located in `templates/durable-objects/`.
+
+### Dependencies
+
+*   **Node.js/npm:** Required for the Cloudflare Wrangler CLI.
+    *   The main `npm install` in the project root is for general tooling if specified.
+    *   The worker itself, located in `templates/durable-objects/`, has its own `package.json`. Ensure dependencies there (especially `wrangler`) are installed by running `npm install` within the `templates/durable-objects/` directory.
+*   **Python/pip:** Required for Django and other Python packages.
+    *   Install project and development dependencies from the root `pyproject.toml` using `pip install -e .[dev]`.
+    *   Ensure `pyproject.toml` correctly defines `[project.optional-dependencies]` for the `dev` group (e.g., `pytest`, `django`).
+
+### Running Tests
+
+1.  **Prerequisites**: Ensure all dependencies are installed as per the "Dependencies" section.
+2.  **Worker Server**: Tests rely on a running Cloudflare worker. The `tests/test_worker.py` file includes a `WorkerFixture` that handles:
+    *   Running `npm install` in `templates/durable-objects/`.
+    *   Starting the `npx wrangler dev` server using the version of `wrangler` specified in `templates/durable-objects/package.json`.
+3.  **Execute Pytest**: Run tests using the `pytest` command from the root of the repository.
+4.  **Test Structure**:
+    *   Integration tests are located in the `tests/` directory. This directory must contain an `__init__.py` file to be treated as a package.
+    *   Tests use the `requests` library to make HTTP calls to the worker.
+    *   The `web_server` fixture (defined in `tests/test_worker.py` and available to all test files) provides the base URL for the running worker.
+    *   Special management URLs (e.g., `/__run_migrations__/`, `/__create_admin__/` in `templates/durable-objects/src/app/urls.py`) are available for test setup. These create an admin user with username `admin` and password `password`.
+
+### Coding Conventions
+
+*   Follow PEP 8 for Python code.
+*   Use Ruff for linting and formatting if configured.
+*   Keep tests focused and independent where possible. The admin tests in `tests/test_admin.py` rely on the admin user created via the management endpoint.
+
+### Key Files and Directories
+
+*   `pyproject.toml`: Defines project metadata, Python dependencies, and build settings for the wrapper/library aspects.
+*   `AGENTS.md`: This file.
+*   `templates/durable-objects/`: Contains the actual Django application deployed to Cloudflare.
+    *   `package.json`: Node.js dependencies for the worker, including `wrangler`.
+    *   `wrangler.toml` (or `wrangler.jsonc`): Wrangler configuration file.
+    *   `src/worker.py`: Python entry point for the worker, using `django-cf` library components.
+    *   `src/app/`: Standard Django project directory.
+        *   `settings.py`: Django settings.
+        *   `urls.py`: Django URL configurations, including admin and management endpoints.
+*   `tests/`: Contains integration tests.
+    *   `__init__.py`: Makes `tests/` a Python package.
+    *   `test_worker.py`: Defines the worker fixture and basic setup tests (migrations, admin creation).
+    *   `test_admin.py`: Contains tests for the Django admin interface (login, logout, etc.).
+
+### Workflow for Future Agents
+
+1.  **Understand the Setup**: The Django app runs inside a Cloudflare Worker, managed by Wrangler. Tests interact with this via HTTP.
+2.  **Dependencies First**: Always ensure both Python (`pip install -e .[dev]`) and Node (`npm install` in the root and `templates/durable-objects/`) dependencies are up to date.
+3.  **Write Tests**: For new Django views or functionalities within `templates/durable-objects/src/app/`, add corresponding integration tests in the `tests/` directory.
+4.  **Run Tests**: Execute `pytest` to verify changes. Debug any worker startup issues by examining output from the `WorkerFixture`.
+5.  **Update AGENTS.md**: If you make significant changes to the testing process, dependency management, or project structure, update this document.
+
+### Troubleshooting Tests
+
+*   **`worker failed to start`**:
+    *   Check the `stdout` and `stderr` printed by the test fixture for errors from `wrangler dev`.
+    *   Ensure `npm install` completed successfully in `templates/durable-objects/`.
+    *   Verify that the port selected by `get_free_port()` is indeed available.
+*   **`ImportError: attempted relative import with no known parent package`**: Ensure `tests/__init__.py` exists.
+*   **CSRF token issues**: The `get_csrf_token` helper in `tests/test_admin.py` is a basic string parser. If Django admin templates change significantly, this helper might need updating (e.g., to use a proper HTML parser).
+
+By following these guidelines, agents can contribute effectively to this repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest",
     "requests",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'tests' directory a Python package.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,169 @@
+import requests
+from urllib.parse import urlparse, parse_qs
+
+# Import the web_server fixture from test_worker
+from .test_worker import web_server
+
+def get_csrf_token(client, url):
+    """Fetches a page and extracts the CSRF token from a form."""
+    try:
+        response = client.get(url, timeout=10)
+        response.raise_for_status()
+        body = response.text
+        start_str = 'name="csrfmiddlewaretoken" value="'
+        start_idx = body.find(start_str)
+        if start_idx == -1:
+            # Fallback for Django 5.0+ where token might be in a script tag or different structure
+            # This is a simplified search and might need adjustment
+            start_str_script = '"csrfToken":"'
+            start_idx_script = body.find(start_str_script)
+            if start_idx_script != -1:
+                start_idx = start_idx_script + len(start_str_script)
+                end_idx = body.find('"', start_idx)
+                if end_idx != -1:
+                    return body[start_idx:end_idx]
+            raise ValueError("CSRF token not found in form or script.")
+
+        start_idx += len(start_str)
+        end_idx = body.find('"', start_idx)
+        if end_idx == -1:
+            raise ValueError("CSRF token not properly formatted in form.")
+        return body[start_idx:end_idx]
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching CSRF token from {url}: {e}")
+        raise
+    except ValueError as e:
+        print(f"Error parsing CSRF token from {url}: {e}")
+        raise
+
+
+def test_admin_login_page_loads(web_server):
+    """Test that the admin login page loads correctly."""
+    admin_url = f"{web_server.base_url}/admin/login/"
+    response = requests.get(admin_url, timeout=10)
+    assert response.status_code == 200
+    assert "Django administration" in response.text
+
+def test_admin_dashboard_unauthorized_access(web_server):
+    """Test that accessing the admin dashboard without login redirects to the login page."""
+    admin_dashboard_url = f"{web_server.base_url}/admin/"
+    login_url = f"{web_server.base_url}/admin/login/"
+
+    client = requests.Session()
+    # First check with allow_redirects=False to see the 302
+    response_no_redirect = client.get(admin_dashboard_url, timeout=10, allow_redirects=False)
+    assert response_no_redirect.status_code == 302
+    location_header = response_no_redirect.headers.get("Location", "")
+    # The location might be relative /admin/login/?next=/admin/ or absolute
+    assert "admin/login" in location_header
+    assert "next=/admin/" in location_header
+
+    # Then check with allow_redirects=True (default) to ensure it lands on the login page
+    response_followed = client.get(admin_dashboard_url, timeout=10)
+    assert response_followed.status_code == 200
+    assert response_followed.url.startswith(login_url) # Final URL should be the login page
+    assert "Django administration" in response_followed.text # Should show the login page content
+
+def test_admin_login_successful(web_server):
+    """Test a successful login to the Django admin."""
+    login_url = f"{web_server.base_url}/admin/login/"
+    admin_dashboard_url = f"{web_server.base_url}/admin/"
+    client = requests.Session()
+
+    csrf_token = get_csrf_token(client, login_url)
+    login_data = {
+        "username": "admin",
+        "password": "password",
+        "csrfmiddlewaretoken": csrf_token,
+        "next": "/admin/",
+    }
+    headers = {"Referer": login_url}
+    response = client.post(login_url, data=login_data, headers=headers, timeout=10)
+
+    assert response.status_code == 200
+    assert response.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert "Site administration" in response.text
+    assert "Log out" in response.text
+
+
+def test_admin_login_failed_wrong_password(web_server):
+    """Test a failed login attempt with a wrong password."""
+    login_url = f"{web_server.base_url}/admin/login/"
+    client = requests.Session()
+    csrf_token = get_csrf_token(client, login_url)
+    login_data = {
+        "username": "admin",
+        "password": "wrongpassword",
+        "csrfmiddlewaretoken": csrf_token,
+        "next": "/admin/",
+    }
+    headers = {"Referer": login_url}
+    response = client.post(login_url, data=login_data, headers=headers, timeout=10)
+
+    assert response.status_code == 200
+    assert "Please enter the correct username and password" in response.text
+    assert "Log out" not in response.text
+
+def test_admin_login_failed_wrong_username(web_server):
+    """Test a failed login attempt with a non-existent username."""
+    login_url = f"{web_server.base_url}/admin/login/"
+    client = requests.Session()
+    csrf_token = get_csrf_token(client, login_url)
+    login_data = {
+        "username": "nonexistentuser",
+        "password": "password",
+        "csrfmiddlewaretoken": csrf_token,
+        "next": "/admin/",
+    }
+    headers = {"Referer": login_url}
+    response = client.post(login_url, data=login_data, headers=headers, timeout=10)
+
+    assert response.status_code == 200
+    assert "Please enter the correct username and password" in response.text
+    assert "Log out" not in response.text
+
+def test_admin_logout(web_server):
+    """Test logging out from the Django admin."""
+    login_url = f"{web_server.base_url}/admin/login/"
+    logout_url = f"{web_server.base_url}/admin/logout/"
+    admin_dashboard_url = f"{web_server.base_url}/admin/"
+    client = requests.Session()
+
+    # 1. Log in first
+    csrf_token_login = get_csrf_token(client, login_url)
+    login_data = {
+        "username": "admin",
+        "password": "password",
+        "csrfmiddlewaretoken": csrf_token_login,
+        "next": "/admin/",
+    }
+    headers_login = {"Referer": login_url}
+    response_login = client.post(login_url, data=login_data, headers=headers_login, timeout=10)
+    assert response_login.status_code == 200
+    assert response_login.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert "Log out" in response_login.text
+
+    # 2. Logout
+    # Django's admin logout is a POST request.
+    # We need a CSRF token. The logout link is usually on an admin page.
+    # We can fetch the admin dashboard (which we are on) to get a CSRF token.
+    # Or, more directly, GET the logout page itself, which shows a confirmation form with a token.
+
+    logout_confirm_response = client.get(logout_url, timeout=10)
+    assert logout_confirm_response.status_code == 200
+    assert "Are you sure you want to log out?" in logout_confirm_response.text # Or similar text
+
+    csrf_token_logout = get_csrf_token(client, logout_url) # Get CSRF from the logout confirmation page
+
+    headers_logout = {"Referer": logout_url}
+    response_logout = client.post(logout_url, data={"csrfmiddlewaretoken": csrf_token_logout}, headers=headers_logout, timeout=10)
+
+    assert response_logout.status_code == 200
+    assert "Logged out" in response_logout.text or "Log in again" in response_logout.text # Django 5.0 shows "Log in again"
+
+    # 3. Verify user is logged out
+    response_dashboard_after_logout = client.get(admin_dashboard_url, timeout=10, allow_redirects=True)
+    assert response_dashboard_after_logout.status_code == 200
+    assert response_dashboard_after_logout.url.startswith(login_url)
+    assert "Django administration" in response_dashboard_after_logout.text
+    assert "Log out" not in response_dashboard_after_logout.text


### PR DESCRIPTION
Added integration tests for the Django admin interface:
- Test admin login page loads
- Test successful admin login
- Test failed admin login (wrong password, wrong username)
- Test unauthorized access to admin dashboard
- Test admin logout

Updated test worker fixture:
- Ensured 'npm install' is run in the worker directory before starting wrangler.
- Changed wrangler command to use the version pinned in package.json.
- Increased server start timeout and improved error reporting if worker fails.

Added AGENTS.md with instructions for future agent development. Added tests/__init__.py to make the tests directory a package. Corrected pyproject.toml to use [project.optional-dependencies].